### PR TITLE
Support hledger ISO date format

### DIFF
--- a/R/register.r
+++ b/R/register.r
@@ -233,7 +233,7 @@ register_hledger <- function(file, flags = "", date = NULL, add_mark = TRUE, add
 
 .clean_hledger <- function(df) {
     if (nrow(df)) {
-        df <- mutate(df, date = as.Date(date, "%Y/%m/%d"))
+        df <- mutate(df, date = as.Date(date, "%Y-%m-%d"))
 
         df <- mutate(df, description = ifelse(grepl("\\|$", .data$description),
                                                      paste0(.data$description, " "),


### PR DESCRIPTION
As of hledger#1157, `hledger` outputs dates in ISO format with `-` instead of `/`.

### Test Plan

~This PR is entirely unexecuted/untested ATM. Merge with caution.~ Tested locally - my dates import well.