### PR TITLE
chore: Prep for CRAN release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ledger
 Type: Package
 Title: Utilities for Importing Data from Plain Text Accounting Files
-Version: 2.0.10-2
+Version: 2.0.11
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-ledger 2.0.10 (development)
-===========================
+ledger 2.0.11
+=============
 
 * ``register_beancount()`` and ``register_hledger()`` now import a transaction `id` column (#21).
   Thanks @vikasrawal for suggestion.

--- a/R/register.r
+++ b/R/register.r
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Trevor L. Davis <trevor.l.davis@gmail.com>
+# Copyright (c) 2024 Trevor L. Davis <trevor.l.davis@gmail.com>
 # Copyright (c) 2018 Jenya Sovetkin <e.sovetkin@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.Rrst
+++ b/README.Rrst
@@ -21,7 +21,7 @@ options(width=80)
 
 |CRAN-status| |R-CMD-check| |codecov| |downloads|
 
-``ledger`` is an R package to import data from `plain text accounting <https://plaintextaccounting.org/>`_ software like `Ledger <https://www.ledger-cli.org/>`_, `HLedger <https://hledger.org/>`_, and `Beancount <https://github.com/beancount/beancount>`_ into an R data frame for convenient analysis, plotting, and export.
+``ledger`` is an R package to import data from `plain text accounting <https://plaintextaccounting.org/>`_ software like `Ledger <https://ledger-cli.org/>`_, `HLedger <https://hledger.org/>`_, and `Beancount <https://github.com/beancount/beancount>`_ into an R data frame for convenient analysis, plotting, and export.
 
 Right now it supports reading in the register from ``ledger``, ``hledger``, and ``beancount`` files.  
 
@@ -46,7 +46,7 @@ To install the development version of the ``ledger`` package (and its R package 
 This package also has some system dependencies that need to be installed depending on which plaintext accounting files you wish to read to be able to read in:
 
 ledger
-    `ledger <https://www.ledger-cli.org/>`_ (>= 3.1) 
+    `ledger <https://ledger-cli.org/>`_ (>= 3.1)
 
 hledger
     `hledger <https://hledger.org/>`_ (>= 1.4)
@@ -66,7 +66,7 @@ To install beancount run the following in your shell:
 
     pip3 install beancount
 
-`Several pre-compiled Ledger binaries are available <https://www.ledger-cli.org/download.html>`_ (often found in several open source repos).
+`Several pre-compiled Ledger binaries are available <https://ledger-cli.org/download.html>`_ (often found in several open source repos).
 
 To run the unit tests you'll also need the suggested R package ``testthat``.
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ ledger
 
 |CRAN-status| |R-CMD-check| |codecov| |downloads|
 
-``ledger`` is an R package to import data from `plain text accounting <https://plaintextaccounting.org/>`_ software like `Ledger <https://www.ledger-cli.org/>`_, `HLedger <https://hledger.org/>`_, and `Beancount <https://github.com/beancount/beancount>`_ into an R data frame for convenient analysis, plotting, and export.
+``ledger`` is an R package to import data from `plain text accounting <https://plaintextaccounting.org/>`_ software like `Ledger <https://ledger-cli.org/>`_, `HLedger <https://hledger.org/>`_, and `Beancount <https://github.com/beancount/beancount>`_ into an R data frame for convenient analysis, plotting, and export.
 
 Right now it supports reading in the register from ``ledger``, ``hledger``, and ``beancount`` files.  
 
@@ -43,7 +43,7 @@ To install the development version of the ``ledger`` package (and its R package 
 This package also has some system dependencies that need to be installed depending on which plaintext accounting files you wish to read to be able to read in:
 
 ledger
-    `ledger <https://www.ledger-cli.org/>`_ (>= 3.1) 
+    `ledger <https://ledger-cli.org/>`_ (>= 3.1)
 
 hledger
     `hledger <https://hledger.org/>`_ (>= 1.4)
@@ -63,7 +63,7 @@ To install beancount run the following in your shell:
 
     pip3 install beancount
 
-`Several pre-compiled Ledger binaries are available <https://www.ledger-cli.org/download.html>`_ (often found in several open source repos).
+`Several pre-compiled Ledger binaries are available <https://ledger-cli.org/download.html>`_ (often found in several open source repos).
 
 To run the unit tests you'll also need the suggested R package ``testthat``.
 

--- a/cran-comments.rst
+++ b/cran-comments.rst
@@ -4,7 +4,7 @@ Depending on the type of plaintext accounting file to be imported this package h
 
 **Test environments**
 
-* local (linux, R 4.1.1) with all of the system dependencies installed
+* local (linux, R 4.4.0) with all of the system dependencies installed
 * win-builder (windows, R devel) with none of the system dependencies installed
 * Github Actions (linux, R devel, R release, R oldrel) with all dependencies installed
 


### PR DESCRIPTION
* Bump version number
* Update test environments used by `cran-comments.rst`
* Tweak permanently moved URL addresses to suppress CRAN NOTE