### PR TITLE
feat: Import transaction code column in register_ledger() (#25)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ledger
 Type: Package
 Title: Utilities for Importing Data from Plain Text Accounting Files
-Version: 2.0.12-1
+Version: 2.0.12-2
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,17 @@ Deprecated features
 * The `"bean-report_ledger"` and `"bean-report_hledger"` toolchains are deprecated since `bean-report` was removed from `beancount` in 2020.
   Use the `"beancount"` toolchain that uses `bean-query` instead.
 
+New features
+------------
+
+* `register_ledger()` now imports a transaction `code` column (#25).
+
+Bug fixes and minor improvements
+--------------------------------
+
+* `register_ledger()` now extracts marks that are embedded in the descriptions which
+  `ledger`'s csv output sometimes does when when both transaction codes and marks are present in the transaction.
+
 ledger 2.0.11
 =============
 

--- a/R/register.R
+++ b/R/register.R
@@ -119,6 +119,7 @@ register <- function(file, ..., toolchain = default_toolchain(file), date = NULL
 		tidyselect::matches("mark$"),
 		"payee",
 		"description",
+		tidyselect::matches("^code$"),
 		"account",
 		"amount",
 		"commodity",
@@ -376,10 +377,31 @@ register_ledger <- function(file, flags = "", date = NULL) {
 }
 
 .clean_ledger <- function(df) {
-	names(df) <- c("date", "V2", "description", "account", "commodity", "amount", "mark", "comment")
+	names(df) <- c(
+		"date",
+		"code",
+		"description",
+		"account",
+		"commodity",
+		"amount",
+		"mark",
+		"comment"
+	)
 	df <- mutate(
 		df,
 		date = as.Date(date, "%Y/%m/%d"),
+		# When a transaction code is present, ledger embeds the mark in the
+		# description instead of the mark column
+		mark = ifelse(
+			.data$mark == "" & grepl("^[*!] ", .data$description),
+			sub("^([*!]) .*", "\\1", .data$description),
+			.data$mark
+		),
+		description = ifelse(
+			grepl("^[*!] ", .data$description),
+			sub("^[*!] ", "", .data$description),
+			.data$description
+		),
 		description = ifelse(
 			grepl("\\|$", .data$description),
 			paste0(.data$description, " "),
@@ -392,9 +414,10 @@ register_ledger <- function(file, flags = "", date = NULL) {
 		),
 		payee = .left_of_split(.data$description, " \\| "),
 		description = .right_of_split(.data$description, " \\| "),
-		payee = ifelse(.data$payee == "", NA, .data$payee),
-		description = ifelse(.data$description == "", NA, .data$description),
+		payee = ifelse(.data$payee == "", NA_character_, .data$payee),
+		description = ifelse(.data$description == "", NA_character_, .data$description),
 		payee = as.character(.data$payee),
+		code = ifelse(.data$code == "", NA_character_, as.character(.data$code)),
 		comment = str_trim(as.character(.data$comment))
 	)
 	df

--- a/inst/extdata/example.ledger
+++ b/inst/extdata/example.ledger
@@ -66,7 +66,7 @@ P 2016/01/01 00:00:00 SP                        250 USD
   Income:Wages:Salary                                              -1500.00 USD
   Equity:Employer                                                  1500.00 USD
 
-2016/01/05 * Uncle Sam | Federal Income Tax Withholding
+2016/01/05 (TAX-001) * Uncle Sam | Federal Income Tax Withholding
   Expenses:Taxes:Federal                                           82.55 USD
   Equity:Employer                                                  -82.55 USD
 
@@ -109,7 +109,7 @@ P 2016/01/01 00:00:00 SP                        250 USD
 
 P 2017/12/31 00:00:00 SP                        500 USD
 
-2018/01/05 ! Deposit to Checking Account
+2018/01/05 (DEP-001) ! Deposit to Checking Account
   Assets:JT-Checking                                               1382.00 USD
   Equity:Transfer                                                  -1382.00 USD
 

--- a/tests/testthat/test-register.R
+++ b/tests/testthat/test-register.R
@@ -73,6 +73,29 @@ for (ii in seq_len(nrow(df_file))) {
 
 		mark <- unique(dplyr::filter(df, description == "Federal Income Tax Withholding")$mark)
 		expect_equal(mark, "*")
+
+		if (toolchain == "ledger") {
+			# code column
+			code <- dplyr::filter(
+				df,
+				description == "Federal Income Tax Withholding",
+				date == "2016-01-05"
+			)$code
+			expect_equal(unique(code), "TAX-001")
+			code_na <- dplyr::filter(
+				df,
+				description == "Federal Income Tax Withholding",
+				date == "2017-01-05"
+			)$code
+			expect_true(all(is.na(code_na)))
+			# mark is correctly extracted from description when code is present
+			tax_mark <- unique(dplyr::filter(df, code == "TAX-001")$mark)
+			expect_equal(tax_mark, "*")
+			dep_mark <- unique(dplyr::filter(df, code == "DEP-001")$mark)
+			expect_equal(dep_mark, "!")
+			# description does not contain leftover mark prefix
+			expect_false(any(grepl("^[*!] ", df$description), na.rm = TRUE))
+		}
 		mark <- dplyr::filter(
 			df,
 			date == "2018-01-05",


### PR DESCRIPTION
* `register_ledger()` now imports a transaction `code` column.
* `register_ledger()` now extracts marks that are embedded in the descriptions which `ledger`'s csv output sometimes does when when both transaction codes and marks are present in the transaction.

closes #25